### PR TITLE
Change hipdrt_printf_alloc from automode to hip

### DIFF
--- a/aomp-device-libs/aompextras/src/hipdrt_printf_alloc.hip
+++ b/aomp-device-libs/aompextras/src/hipdrt_printf_alloc.hip
@@ -1,10 +1,12 @@
 //===----------------------------------------------------------------------===//
-// hipdrt_printf_alloc.cl: device runtime routine for allocating print buffer
+// hipdrt_printf_alloc.hip: device runtime routine for allocating print buffer
 //
 // This file is dual licensed under the MIT and the University of Illinois Open
 // Source Licenses. See LICENSE.txt for details.
 //
 //===----------------------------------------------------------------------===//
+
+#include "hip_minimal.h"
 
 #define HIP_VERSION 0
 #define HIP_RELEASE 0


### PR DESCRIPTION
Change hipdrt_printf_alloc from automode to hip
Identical IR generated from automode as from using hip with the hip_minimal header