### PR TITLE
Drop dependency on hip_runtime.h from hostcall, associated cleanup

### DIFF
--- a/hostcall/include/hostcall_service_id.h
+++ b/hostcall/include/hostcall_service_id.h
@@ -45,7 +45,7 @@ SOFTWARE.
 #define HOSTCALL_VERSION_RELEASE ((HOSTCALL_VERSION * 64) + HOSTCALL_RELEASE)
 typedef short hostcall_version_t;
 
-#define PACK_VERS(x) ((uint) HOSTCALL_VRM << 16) | ((uint) x)
+#define PACK_VERS(x) ((uint32_t) HOSTCALL_VRM << 16) | ((uint32_t) x)
 
 enum hostcall_service_id {
   HOSTCALL_SERVICE_UNUSED,

--- a/hostcall/include/hostcall_stubs.h
+++ b/hostcall/include/hostcall_stubs.h
@@ -1,18 +1,24 @@
+#ifndef HOSTCALL_STUBS_H
+#define HOSTCALL_STUBS_H
 
-#define EXTERN extern "C" __device__
+#define EXTERN extern "C" __attribute__((device))
+
+#include <stdint.h>
 
 /* These are the interfaces for the device stubs */
 ///
 EXTERN int printf( const char * , ...);
-EXTERN char *  printf_alloc(uint bufsz);
-EXTERN int     printf_execute(char * bufptr, uint bufsz);
+EXTERN char *  printf_alloc(uint32_t bufsz);
+EXTERN int     printf_execute(char * bufptr, uint32_t bufsz);
 EXTERN uint32_t __strlen_max(char*instr, uint32_t maxstrlen);
 EXTERN int     vector_product_zeros(int N, int*A, int*B, int*C);
 
 typedef struct hostcall_result_s{
-  ulong arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
+  uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
 } hostcall_result_t;
 
-EXTERN hostcall_result_t hostcall_invoke(uint id,
-    ulong arg0, ulong arg1, ulong arg2, ulong arg3,
-    ulong arg4, ulong arg5, ulong arg6, ulong arg7);
+EXTERN hostcall_result_t hostcall_invoke(uint32_t id,
+    uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3,
+    uint64_t arg4, uint64_t arg5, uint64_t arg6, uint64_t arg7);
+
+#endif

--- a/hostcall/libdevice/CMakeLists.txt
+++ b/hostcall/libdevice/CMakeLists.txt
@@ -112,8 +112,6 @@ macro(add_hip_bc_library name dir)
     -I${HIPINC}
     -I${ROCM_DIR}/include)
 
-#    --hip-auto-headers=cuda_open
-#    --hip-auto-headers=cuda
   set(bc1_files)
 
   foreach(file ${ARGN})

--- a/hostcall/libdevice/src/hostcall_invoke.cl
+++ b/hostcall/libdevice/src/hostcall_invoke.cl
@@ -48,12 +48,6 @@ send_signal(hsa_signal_t signal)
 }
 
 static ulong
-get_ptr_tag(ulong ptr, uint index_size)
-{
-    return ptr >> index_size;
-}
-
-static ulong
 get_ptr_index(ulong ptr, uint index_size)
 {
     return ptr & (((ulong)1 << index_size) - 1);

--- a/hostcall/libdevice/src/hostcall_stubs.hip
+++ b/hostcall/libdevice/src/hostcall_stubs.hip
@@ -2,7 +2,6 @@
 ///  hostcall_stubs.hip
 ///
 
-#include "hip/hip_runtime.h"
 #include "hostcall_service_id.h"
 #include "hostcall_stubs.h"
 // -----------------------------------------------------------------------------
@@ -20,20 +19,20 @@
 // host routine for printf_execute will free the buffer that was allocated
 // by printf_alloc.
 
-EXTERN char * printf_alloc(uint bufsz) {
-  ulong arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
-  arg0 = (ulong) bufsz;
+EXTERN char * printf_alloc(uint32_t bufsz) {
+  uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
+  arg0 = (uint64_t) bufsz;
   hostcall_result_t result = hostcall_invoke(PACK_VERS(HOSTCALL_SERVICE_MALLOC),
     arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7);
   __builtin_amdgcn_wave_barrier();
   return (char *) result.arg1;
 }
 
-EXTERN int printf_execute(char * print_buffer, uint bufsz) { 
-  ulong arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
+EXTERN int printf_execute(char * print_buffer, uint32_t bufsz) { 
+  uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
   __builtin_amdgcn_wave_barrier();
-  arg0 = (ulong) bufsz;
-  arg1 = (ulong) print_buffer ;
+  arg0 = (uint64_t) bufsz;
+  arg1 = (uint64_t) print_buffer ;
   hostcall_result_t result = hostcall_invoke(PACK_VERS(HOSTCALL_SERVICE_PRINTF),
     arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7);
   return (int) result.arg0;
@@ -74,15 +73,14 @@ EXTERN uint32_t __strlen_max(char *instr, uint32_t maxstrlen) {
 //
 
 EXTERN int vector_product_zeros(int N, int*A,  int*B, int*C) {
-  ulong arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
-  arg0 = (long) N;
+  uint64_t arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7;
+  arg0 = (int64_t) N;
   // Pass these pointers to the host for memcpy
-  arg1 = (long) A;
-  arg2 = (long) B;
-  arg3 = (long) C;
+  arg1 = (int64_t) A;
+  arg2 = (int64_t) B;
+  arg3 = (int64_t) C;
   hostcall_result_t result = hostcall_invoke(PACK_VERS(HOSTCALL_SERVICE_DEMO),
     arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7);
-  int rc = (int) result.arg0;
   int num_zeros = (int) result.arg1;
   return num_zeros;
 }


### PR DESCRIPTION
Hostcall has some device side library code written in a mixture of opencl and hip.

This commit drops a dependency on hip_runtime, replaces opencl types with standard ones where they're used from hip code and does a few miscellaneous cleanups in passing.