### PR TITLE
Add --rocm-path to the compile options

### DIFF
--- a/aomp-device-libs/aompextras/CMakeLists.txt
+++ b/aomp-device-libs/aompextras/CMakeLists.txt
@@ -85,7 +85,7 @@ foreach(mcpu ${mcpus})
 set(hip_bc_files)
 
 set(hip_cmd ${LLVM_COMPILER}/bin/clang++ -c -emit-llvm -x hip
-    --cuda-device-only --offload-arch=${mcpu} -O2 -std=c++11
+	--cuda-device-only --offload-arch=${mcpu} --rocm-path=${LLVM_INSTALL_PREFIX} -O2 -std=c++11
     -I${CMAKE_CURRENT_SOURCE_DIR}/../include 
     -I${CMAKE_CURRENT_SOURCE_DIR}/src)
 

--- a/aomp-device-libs/libm/CMakeLists.txt
+++ b/aomp-device-libs/libm/CMakeLists.txt
@@ -67,6 +67,7 @@ foreach(mcpu ${gpulist})
     -march=${mcpu}
     -emit-llvm
     -DNO_LIBM_HEADER_DEFS=1
+    --rocm-path=${LLVM_INSTALL_PREFIX}
     -O${optimization_level}
     -I${CMAKE_CURRENT_SOURCE_DIR}/src
     -I${LLVM_LIBRARY_DIRS}/libdevice/include)


### PR DESCRIPTION
When ROCm is installed in a custom directory, clang does not find it automatically; therefore, the `--rocm-path` flag needs to be added. This PR adds the flag pointing to the rocm installation. 