### PR TITLE
Build hip source without requiring rocm gpu libs

### DIFF
--- a/aomp-device-libs/aompextras/CMakeLists.txt
+++ b/aomp-device-libs/aompextras/CMakeLists.txt
@@ -85,6 +85,7 @@ foreach(mcpu ${mcpus})
 set(hip_bc_files)
 
 set(hip_cmd ${LLVM_COMPILER}/bin/clang++ -c -emit-llvm -x hip
+    -nogpulib -nogpuinc
     --cuda-device-only --offload-arch=${mcpu} -O2 -std=c++11
     -I${CMAKE_CURRENT_SOURCE_DIR}/../include 
     -I${CMAKE_CURRENT_SOURCE_DIR}/src)


### PR DESCRIPTION
The aomp-extras device library is bitcode. The hip libraries aren't (or at least shouldn't/don't need to be) linked against it.

Dropping the unused hip search path proved contentious, therefore only pass -nogpulib and leave the dead code in cmake.