### PR TITLE
Change uses of uname to be more portable by using the -m option.

### DIFF
--- a/utils/bin/aompcc
+++ b/utils/bin/aompcc
@@ -321,7 +321,7 @@ if [ $VERBOSE ] ; then
    echo "#   "
 fi 
 
-UNAMEP=`uname -p`
+UNAMEP=`uname -m`
 HOST_TARGET="$UNAMEP-pc-linux-gnu"
 if [ "$UNAMEP" == "ppc64le" ] ; then 
   HOST_TARGET="ppc64le-linux-gnu"

--- a/utils/bin/raja_build.sh
+++ b/utils/bin/raja_build.sh
@@ -154,7 +154,7 @@ fi
 mkdir -p $RAJA_BUILD_DIR
 cd $RAJA_BUILD_DIR
 
-UNAMEP=`uname -p`
+UNAMEP=`uname -m`
 AOMP_CPUTARGET="${UNAMEP}-pc-linux-gnu"
 if [ "$UNAMEP" == "ppc64le" ] ; then
    AOMP_CPUTARGET="ppc64le-linux-gnu"


### PR DESCRIPTION
Additional changes for issue #138 https://github.com/ROCm-Developer-Tools/aomp/issues/138