### PR TITLE
Add soft link for aompcc for UC build.

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -177,4 +177,9 @@ else()
      ${CMAKE_CURRENT_SOURCE_DIR}/bin/mygpu
      ${CMAKE_CURRENT_BINARY_DIR}/prepare-builtins
    DESTINATION "rocm-bin")
+
+  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/aompcc DESTINATION "bin")
+
+  # Create soft link for rocm/bin/aompcc -> rocm/llvm/bin/aompcc.
+  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../llvm/bin/aompcc ${CMAKE_INSTALL_PREFIX}/rocm-bin/aompcc)"
 endif()


### PR DESCRIPTION
Soft link will reside in /opt/rocm/bin/aompcc and point to ../llvm/bin/aompcc.