### PR TITLE
ROCm 5.3 package reorg.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(aomp-extras)
+if(${ENABLE_DEVEL_PACKAGE})
+  set(DEVEL_PACKAGE "devel/")
+endif()
 add_subdirectory(utils)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -168,4 +168,4 @@ install(PROGRAMS
    ${CMAKE_CURRENT_SOURCE_DIR}/bin/raja.patch
    ${CMAKE_CURRENT_BINARY_DIR}/clang-ocl
    ${CMAKE_CURRENT_BINARY_DIR}/modulefile
-   DESTINATION "bin")
+   DESTINATION "${DEVEL_PACKAGE}bin")


### PR DESCRIPTION
 This splits openmp-extras package into runtime and development
with the help of additional patches in various openmp-extras repos.