### PR TITLE
ROCm 5.3 package reorg. (#44)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(aomp-extras)
+if(${ENABLE_DEVEL_PACKAGE})
+  set(DEVEL_PACKAGE "devel/")
+endif()
 add_subdirectory(utils)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -178,5 +178,5 @@ else()
      ${CMAKE_CURRENT_SOURCE_DIR}/bin/mygpu
      ${CMAKE_CURRENT_SOURCE_DIR}/bin/openmpi_set_cu_mask
      ${CMAKE_CURRENT_BINARY_DIR}/gpurun
-   DESTINATION "bin")
+   DESTINATION "${DEVEL_PACKAGE}bin")
 endif()


### PR DESCRIPTION
Split openmp package to runtime and devel

Change-Id: I9aa0d7d0627e07f76fe45f33e7cf89b04369610e

Co-authored-by: Ethan Stewart <ethan.stewart@amd.com>