### PR TITLE
[Kokkos] Updates build script for kokkos

### DIFF
--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -274,7 +274,7 @@ else
    # ensure kokkos finds AOMP clang first
    export PATH=$AOMP/bin:$PATH
    ARGS=(
-    -D CMAKE_BUILD_TYPE=Debug
+    -D CMAKE_BUILD_TYPE=Release
     -D CMAKE_CXX_STANDARD=17
     -D CMAKE_CXX_EXTENSIONS=OFF
     -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
@@ -284,7 +284,7 @@ else
     -D Kokkos_ENABLE_OPENMP=ON
     -D Kokkos_ENABLE_OPENMPTARGET=ON
     -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
-    -D Kokkos_ENABLE_TESTS=OFF
+    -D Kokkos_ENABLE_TESTS=ON
    )
 
 fi

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -38,10 +38,11 @@ function print_error() {
 
   echo "[Error]: $toPrint"
 }
-
-AOMP=${AOMP:-$_AOMP_INSTALL_DIR_}
+echo "$AOMP"
+AOMP="${AOMP:-_AOMP_INSTALL_DIR_}"
+echo "$AOMP"
 if [ ! -d $AOMP ] ; then
-   print_error "AOMP is not installed in $AOMP. Please set the environment variable."
+   print_error "AOMP is not installed in ${AOMP}. Please set the environment variable."
    exit 1
 fi
 
@@ -269,8 +270,11 @@ else
     -D Kokkos_ENABLE_OPENMP=ON
     -D Kokkos_ENABLE_OPENMPTARGET=ON
     -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
-    -D Kokkos_ENABLE_TESTS=ON
+    -D Kokkos_ENABLE_TESTS=OFF
    )
+
+   print_info "Running cmake via"
+   echo "cmake ${ARGS[@]} $KOKKOS_SOURCE_DIR"
    cmake "${ARGS[@]}" $KOKKOS_SOURCE_DIR
 fi
 if [ $? != 0 ] ; then
@@ -278,6 +282,7 @@ if [ $? != 0 ] ; then
    echo "ERROR in Kokkos cmake"
    echo "If HWLOC is not found, set environment variable HWLOC_DIR=/path/to/hwloc."
    echo
+   echo "cmake ${ARGS[@]} $KOKKOS_SOURCE_DIR"
    exit 1
 fi
 

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -186,7 +186,7 @@ EOF
     print_error "Patching unsuccessful"
     exit -1
   fi
-  #rm $patchfile1
+ rm $patchfile1
 }
 
 mkdir -p $GIT_DIR
@@ -253,6 +253,8 @@ if [ "$UNAMEP" == "ppc64le" ] ; then
    AOMP_CPUTARGET="ppc64le-linux-gnu"
 fi
 
+export PATH=$HOME/local/install/cmake/bin:$PATH
+
 if [ "$kokkos_backend" == "hip" ] ; then
   export PATH=$AOMP/bin:$PATH
   export ROCM_PATH=$AOMP # Kokkos searches this for HIP parts
@@ -279,6 +281,7 @@ else
     -D CMAKE_CXX_EXTENSIONS=OFF
     -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
     -D CMAKE_CXX_COMPILER=$AOMP/bin/clang++
+    -D CMAKE_VERBOSE_MAKEFILE=ON
     -D Kokkos_ARCH_NATIVE=ON
     -D Kokkos_ARCH_"$KOKKOS_ARCH"=ON
     -D Kokkos_ENABLE_OPENMP=ON

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -57,6 +57,7 @@ KOKKOS_SHA=7c76889 # This is pretty old
 KOKKOS_SHA=${_KOKKOS_SHA_:-}
 NUM_THREADS=${NUM_THREADS:-8}
 
+
 if [[ "$AOMP" =~ "opt" ]]; then
   # xargs trims the string off whitespaces
   export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
@@ -254,6 +255,7 @@ if [ "$UNAMEP" == "ppc64le" ] ; then
 fi
 
 export PATH=$HOME/local/install/cmake/bin:$PATH
+which cmake
 
 if [ "$kokkos_backend" == "hip" ] ; then
   export PATH=$AOMP/bin:$PATH
@@ -311,7 +313,7 @@ echo
 print_info "Starting build ..."
 
 print_info make -j$NUM_THREADS
-make -j$NUM_THREADS
+CCC_OVERRIDE_OPTIONS="--O3 +-O2" make -j$NUM_THREADS
 
 if [ $? != 0 ] ; then
    print_error "ERROR in Kokkos build"

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -254,8 +254,22 @@ if [ "$UNAMEP" == "ppc64le" ] ; then
 fi
 
 if [ "$kokkos_backend" == "hip" ] ; then
-   print_error "hip backend for kokkos not supported yet"
-   exit 1
+  export PATH=$AOMP/bin:$PATH
+  export ROCM_PATH=$AOMP # Kokkos searches this for HIP parts
+  ARGS=(
+    -D CMAKE_BUILD_TYPE=Debug
+    -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
+    -D CMAKE_CXX_STANDARD=17
+    -D CMAKE_CXX_EXTENSIONS=OFF
+    -D CMAKE_CXX_COMPILER=$AOMP/bin/clang++
+    -D Kokkos_ARCH_NATIVE=ON
+    -D Kokkos_ARCH_"$KOKKOS_ARCH"=ON
+    -D Kokkos_ENABLE_OPENMP=ON
+    -D Kokkos_ENABLE_HIP=ON
+    -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
+    -D Kokkos_ENABLE_TESTS=OFF
+  )
+
 else
    # ensure kokkos finds AOMP clang first
    export PATH=$AOMP/bin:$PATH
@@ -273,10 +287,12 @@ else
     -D Kokkos_ENABLE_TESTS=OFF
    )
 
+fi
+
    print_info "Running cmake via"
    echo "cmake ${ARGS[@]} $KOKKOS_SOURCE_DIR"
    cmake "${ARGS[@]}" $KOKKOS_SOURCE_DIR
-fi
+
 if [ $? != 0 ] ; then
    echo
    echo "ERROR in Kokkos cmake"

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -63,11 +63,11 @@ if [[ "$AOMP" =~ "opt" ]]; then
   #print_info "Set AOMP_GPU with rocm_agent_enumerator.
   #export DETECTED_GPU=$($AOMP/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
 else
-  print_info "Set AOMP_GPU with rocminfo."
+  print_info "Set AOMP_GPU with offload-arch."
   if [ -a $AOMP/bin/rocminfo ]; then
-    export DETECTED_GPU=$($AOMP/bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} |  awk '{print $2}')
+    export DETECTED_GPU=$($AOMP/bin/offload-arch | grep -m 1 -E gfx[^0]{1}.{2})
   else
-    export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} |  awk '{print $2}')
+    export DETECTED_GPU=$($AOMP/bin/offload-arch | grep -m 1 -E gfx[^0]{1}.{2})
   fi
 fi
 

--- a/utils/bin/kokkos_build.sh
+++ b/utils/bin/kokkos_build.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved. 
-# 
+# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 # of the Software, and to permit persons to whom the Software is furnished to do so,
 # subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -19,7 +19,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-#  kokkos_build.sh: Script to clone and build kokkos for a specific GPU 
+#  kokkos_build.sh: Script to clone and build kokkos for a specific GPU
 #                   This will build kokkos in directory $HOME/kokkos_build.<GPUNAME>
 #
 #
@@ -28,64 +28,89 @@
 PROGVERSION="X.Y-Z"
 #
 
-AOMP=${AOMP:-_AOMP_INSTALL_DIR_}
+function print_info() {
+  toPrint="$1"
+
+  echo "[Info]: $toPrint"
+}
+function print_error() {
+  toPrint="$1"
+
+  echo "[Error]: $toPrint"
+}
+
+AOMP=${AOMP:-$_AOMP_INSTALL_DIR_}
 if [ ! -d $AOMP ] ; then
-   echo "ERROR:  AOMP is not installed in $AOMP"
+   print_error "AOMP is not installed in $AOMP. Please set the environment variable."
    exit 1
 fi
 
 GIT_DIR=${GIT_DIR:-$HOME/git}
 KOKKOS_SOURCE_DIR=${KOKKOS_SOURCE_DIR:-$GIT_DIR/kokkos}
 KOKKOS_URL=https://github.com/kokkos/kokkos.git
-KOKKOS_BRANCH=develop
-KOKKOS_TAG=7c76889
+# Per default (for now) we want to use release 3.7.00 to establish a working baseline.
+KOKKOS_TAG=${_KOKKOS_TAG_:-3.7.00}
+# For development we also want to pull-in (most recent) devel
+KOKKOS_BRANCH=${_KOKKOS_BRANCH_:-develop}
+KOKKOS_SHA=7c76889 # This is pretty old
+KOKKOS_SHA=${_KOKKOS_SHA_:-}
 NUM_THREADS=${NUM_THREADS:-8}
 
 if [[ "$AOMP" =~ "opt" ]]; then
-  echo Set AOMP_GPU with rocm_agent_enumerator.
-  export DETECTED_GPU=$($AOMP/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
+  # xargs trims the string off whitespaces
+  export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
+  print_info "Set AOMP_GPU with rocminfo: $DETECTED_GPU"
+  #print_info "Set AOMP_GPU with rocm_agent_enumerator.
+  #export DETECTED_GPU=$($AOMP/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
 else
-  echo Set AOMP_GPU with mygpu.
-  if [ -a $AOMP/bin/mygpu ]; then
-    export DETECTED_GPU=$($AOMP/bin/mygpu)
+  print_info "Set AOMP_GPU with rocminfo."
+  if [ -a $AOMP/bin/rocminfo ]; then
+    export DETECTED_GPU=$($AOMP/bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} |  awk '{print $2}')
   else
-    export DETECTED_GPU=$($AOMP/../bin/mygpu)
+    export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} |  awk '{print $2}')
   fi
 fi
+
+AOMP_VERSION=$($AOMP/bin/clang++ --version | head -n 1)
 
 AOMP_GPU=${AOMP_GPU:-$DETECTED_GPU}
 
 # Determine if AOMP_GPU is supported in KOKKOS. Currently looks for AMD only.
 kokkos_regex="gfx(.*)"
-supported_arch="900 906 908"
+supported_arch="900 906 908 90a"
 declare -A arch_array
-echo "Supported KOKKOS GFX: $supported_arch"
+print_info "Supported KOKKOS GFX: $supported_arch"
 
 # Store arch in associative array
 for arch in $supported_arch; do
-  arch_array[$arch]=""
+  # Add name used in Kokkos CMake for Architecture
+  arch_str="VEGA${arch^^}"
+  arch_array[$arch]=$arch_str
 done
 
 if [[ "$AOMP_GPU" =~ $kokkos_regex ]]; then
   matched_arch=${BASH_REMATCH[1]}
 else
-  echo "Error: Cannot determine KOKKOS_ARCH"
+  print_error "Error: Cannot determine KOKKOS_ARCH"
 fi
 
 # Check if matched_arch is present in array
 if [[  -v arch_array[$matched_arch] ]]; then
-  KOKKOS_ARCH=${KOKKOS_ARCH:-$matched_arch}
+  # Get Kokkos name for arch
+  KOKKOS_ARCH=${KOKKOS_ARCH:-${arch_array["$matched_arch"]}}
 else
-  echo "Error: gfx"$matched_arch" is currently not supported in KOKKOS"
+  print_error "Error: gfx${matched_arch} is currently not supported in KOKKOS"
   exit 1
 fi
 
-echo AOMP_GPU    = $AOMP_GPU
-echo KOKKOS_ARCH = $KOKKOS_ARCH
-echo AOMP        = $AOMP
+print_info "Using configuration"
+print_info "AOMP_GPU    = $AOMP_GPU"
+print_info "KOKKOS_ARCH = $KOKKOS_ARCH"
+print_info "AOMP        = $AOMP"
+print_info "AOMP Version = $AOMP_VERSION"
 
 if [ "$AOMP_GPU" == "" ] || [ "$AOMP_GPU" == "unknown" ]; then
-  echo Error: AOMP_GPU not properly set...exiting.
+  print_error "Error: AOMP_GPU not properly set...exiting."
   exit 1
 fi
 
@@ -109,87 +134,117 @@ fi
 
 # Clean install, build and source directories
 if [ "$1" == "clean" ] ; then
-  echo Cleaning:
-  echo SOURCE_DIR: $KOKKOS_SOURCE_DIR
-  echo BUILD_DIR: $KOKKOS_BUILD_DIR
-  echo INSTALL_DIR: $KOKKOS_INSTALL_DIR
+  print_info "Cleaning:"
+  print_info "SOURCE_DIR: $KOKKOS_SOURCE_DIR"
+  print_info "BUILD_DIR: $KOKKOS_BUILD_DIR"
+  print_info "INSTALL_DIR: $KOKKOS_INSTALL_DIR"
   rm -rf $KOKKOS_SOURCE_DIR
   rm -rf $KOKKOS_BUILD_DIR
   rm -rf $KOKKOS_INSTALL_DIR
   exit 0
 fi
 
+# This patch is required for Debug builds of Clang/LLVM for a Clang assertion failing
+# otherwise: Non-trivially copyable data types used by Kokkos.
 function patchkokkos(){
 patchfile1=/tmp/kokkos1_$$.patch
 /bin/cat >$patchfile1 <<"EOF"
-diff --git a/core/unit_test/CMakeLists.txt b/core/unit_test/CMakeLists.txt
-index b616e80f..0495f630 100644
---- a/core/unit_test/CMakeLists.txt
-+++ b/core/unit_test/CMakeLists.txt
-@@ -138,7 +138,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;HIP;SYCL)
-         Reducers_a
-         Reducers_b
-         Reducers_c
--        Reducers_d
-+        #Reducers_d
-         Reductions_DeviceView
-         Scan
-         SharedAlloc
-@@ -309,7 +309,7 @@ IF(KOKKOS_ENABLE_OPENMPTARGET
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_a.cpp
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_b.cpp
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_c.cpp
--    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-+#    ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Reducers_d.cpp
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_ViewMapping_b.cpp
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_TeamBasic.cpp
-     ${CMAKE_CURRENT_BINARY_DIR}/openmptarget/TestOpenMPTarget_Scan.cpp
+From e1a19dda160751eefb6b70a204a21db7a93c48b1 Mon Sep 17 00:00:00 2001
+From: JP Lehr <JanPatrick.Lehr@amd.com>
+Date: Mon, 31 Oct 2022 15:17:58 +0000
+Subject: [PATCH] Only to create a path
+
+---
+core/unit_test/TestNonTrivialScalarTypes.hpp | 2 ++
+1 file changed, 2 insertions(+)
+
+diff --git a/core/unit_test/TestNonTrivialScalarTypes.hpp b/core/unit_test/TestNonTrivialScalarTypes.hpp
+index 02064d2fc..e593e7e3d 100644
+--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
++++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
+@@ -158,10 +158,12 @@ struct array_reduce {
+   array_reduce() {
+     for (int i = 0; i < N; i++) data[i] = scalar_t();
+   }
++#if 0
+   KOKKOS_INLINE_FUNCTION
+   array_reduce(const array_reduce &rhs) {
+     for (int i = 0; i < N; i++) data[i] = rhs.data[i];
+   }
++#endif
+   KOKKOS_INLINE_FUNCTION
+   array_reduce(const scalar_t value) {
+     for (int i = 0; i < N; i++) data[i] = scalar_t(value);
+---
+2.25.1
+
 EOF
-  echo patch -p1 $patchfile1
+  print_info "patch -p1 < $patchfile1"
   patch -p1 < $patchfile1
-  rm $patchfile1
+  if [[ $? -ne 0 ]]; then
+    print_error "Patching unsuccessful"
+    exit -1
+  fi
+  #rm $patchfile1
 }
 
 mkdir -p $GIT_DIR
 cd $GIT_DIR
-if [ ! -d $KOKKOS_SOURCE_DIR ] ; then 
-   echo git clone -b develop $KOKKOS_URL
-   git clone -b $KOKKOS_BRANCH $KOKKOS_URL
-   if [ $? != 0 ] ; then 
+if [ ! -d $KOKKOS_SOURCE_DIR ] ; then
+   print_info "git clone $KOKKOS_URL"
+   git clone $KOKKOS_URL kokkos
+   if [ $? != 0 ] ; then
       echo
-      echo "ERROR: Could not git clone $KOKKOS_URL "
-      echo
+      print_error "ERROR: Could not git clone $KOKKOS_URL "
       exit 1
    fi
    cd $KOKKOS_SOURCE_DIR
-   git checkout $KOKKOS_TAG
+   print_info "Checking out Kokkos branch: ${KOKKOS_BRANCH}"
+   git checkout $KOKKOS_BRANCH
+   if [ $? != 0 ] ; then
+      echo
+      print_error "ERROR: Could not check out $KOKKOS_BRANCH"
+      exit 1
+   fi
+   if [[ ! -z $KOKKOS_TAG ]]; then
+     print_info "Switch to Kokkos tag: ${KOKKOS_TAG}"
+     git checkout $KOKKOS_TAG
+   elif [[ ! -z $KOKKOS_SHA ]]; then
+     print_info "Switch to Kokkos SHA: ${KOKKOS_SHA}"
+     git checkout $KOKKOS_SHA
+   else
+     print_info "Running on $KOKKOS_BRANCH HEAD"
+   fi
    if [ "$PATCH" != 0 ]; then
-     echo "patching..."
+     print_info "patching..."
      patchkokkos
    else
-     echo "PATCH=0 - not patching KOKKOS"
+     print_info "PATCH=0 - not patching KOKKOS"
    fi
-else 
+else
    echo
    echo "  WARNING: Directory $KOKKOS_SOURCE_DIR already exists."
    echo "           No changes will be made to the sources"
    echo
 fi
 
-if [ -d $KOKKOS_BUILD_DIR ] ; then 
+if [ -d "$KOKKOS_BUILD_DIR" ] ; then
    echo
    echo " FRESH START:  Removing $KOKKOS_BUILD_DIR"
    echo "               rm -rf $KOKKOS_BUILD_DIR"
    echo
    rm -rf  $KOKKOS_BUILD_DIR
 fi
-if [ -d $KOKKOS_INSTALL_DIR ] ; then 
+if [ -d "$KOKKOS_INSTALL_DIR" ] ; then
    echo "               rm -rf $KOKKOS_INSTALL_DIR"
    echo
    rm -rf  $KOKKOS_INSTALL_DIR
 fi
+
+print_info "$KOKKOS_BUILD_DIR"
+
 mkdir -p $KOKKOS_BUILD_DIR
-cd $KOKKOS_BUILD_DIR
+cd "$KOKKOS_BUILD_DIR"
 
 UNAMEP=`uname -m`
 AOMP_CPUTARGET="${UNAMEP}-pc-linux-gnu"
@@ -198,18 +253,19 @@ if [ "$UNAMEP" == "ppc64le" ] ; then
 fi
 
 if [ "$kokkos_backend" == "hip" ] ; then
-   echo "ERROR: hip backend for kokkos not supported yet"
+   print_error "hip backend for kokkos not supported yet"
    exit 1
 else
    # ensure kokkos finds AOMP clang first
    export PATH=$AOMP/bin:$PATH
-   ARGS=( 
+   ARGS=(
     -D CMAKE_BUILD_TYPE=Debug
     -D CMAKE_CXX_STANDARD=17
     -D CMAKE_CXX_EXTENSIONS=OFF
     -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
-    -D Kokkos_ARCH_VEGA"$KOKKOS_ARCH"=ON
     -D CMAKE_CXX_COMPILER=$AOMP/bin/clang++
+    -D Kokkos_ARCH_NATIVE=ON
+    -D Kokkos_ARCH_"$KOKKOS_ARCH"=ON
     -D Kokkos_ENABLE_OPENMP=ON
     -D Kokkos_ENABLE_OPENMPTARGET=ON
     -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
@@ -217,7 +273,7 @@ else
    )
    cmake "${ARGS[@]}" $KOKKOS_SOURCE_DIR
 fi
-if [ $? != 0 ] ; then 
+if [ $? != 0 ] ; then
    echo
    echo "ERROR in Kokkos cmake"
    echo "If HWLOC is not found, set environment variable HWLOC_DIR=/path/to/hwloc."
@@ -228,22 +284,22 @@ fi
 echo
 echo "CMAKE done in directory $KOKKOS_BUILD_DIR"
 echo
-echo "Starting build ..."
+print_info "Starting build ..."
 
-echo make -j$NUM_THREADS
+print_info make -j$NUM_THREADS
 make -j$NUM_THREADS
 
-if [ $? != 0 ] ; then 
-   echo "ERROR in Kokkos build"
+if [ $? != 0 ] ; then
+   print_error "ERROR in Kokkos build"
    exit 1
 fi
 
 make install
-if [ $? != 0 ] ; then 
-   echo "ERROR in Kokkos install"
+if [ $? != 0 ] ; then
+   print_error "ERROR in Kokkos install"
    exit 1
 fi
 echo
-echo " Kokkos Version $KOKKOS_TAG installed successfully into directory "
+echo " Kokkos Version $KOKKOS_SHA installed successfully into directory "
 echo " $KOKKOS_INSTALL_DIR"
 echo


### PR DESCRIPTION
- Pulls in 3.7.00 release version of Kokkos
- Uses rocminfo to determine the system's GPU
- Smaller changes where CMake flags are generated
- Adds print_info and print_error functions for more homogenous handling of output
- Allows to pull-in other branches/tags/shas via environment variables: _KOKKOS_BRANCH_, _KOKKOS_TAG_, _KOKKOS_SHA_