### PR TITLE
add init for NUMANODE if null , works around virtualized hyabusa 16 g…

### DIFF
--- a/utils/bin/gpurun
+++ b/utils/bin/gpurun
@@ -336,6 +336,7 @@ fi
 NUMANODE=`cat /sys/bus/pci/devices/0000:$_bdfidstrc.0/numa_node`
 # Sometimes lscpu shows 0 for the node, when /sys/bus/pci/.. shows -1
 [[ $NUMANODE == -1 ]] && NUMANODE=0
+[[ "$NUMANODE" == "" ]] && NUMANODE=0
 _taskset_cmd="taskset -c "
 lscpu --extended=cpu,node >$_tfile
 while read _linepair ; do


### PR DESCRIPTION
…pus issues

the hyabusa system from MSFT has a very different structure, this slightly gets past abort in gpurun script