### PR TITLE
[Kokkos] Remove old test result files before new run

### DIFF
--- a/utils/bin/kokkos_run.sh
+++ b/utils/bin/kokkos_run.sh
@@ -150,6 +150,9 @@ if [ $KOKKOS_RUN_UNIT_TEST == 'yes' ]; then
       EXE_FILES+=("$EXE")
     done
 
+    # Rmove previous test results
+    find . -iname "RESULT_*" -delete
+
     # 2. Query each executable for all contained test cases
     for UT in "${EXE_FILES[@]}"; do
       echo "Executable $UT"


### PR DESCRIPTION
This fixes the issue that result files were left over from a previous run, thus not correctly showing problems with the unit tests.