### PR TITLE
build: bump minimum required version of CMake to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(aomp-extras)
 include(GNUInstallDirs)
 if(${ENABLE_DEVEL_PACKAGE})

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   project(aomputils)
 endif()


### PR DESCRIPTION
CMake 4 drops support of <3.5
https://cmake.org/cmake/help/latest/release/4.0.html#id14